### PR TITLE
Require docker&&linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ def imageName = 'jenkinsciinfra/confluence-cache'
 properties([[$class: 'BuildDiscarderProperty',
                 strategy: [$class: 'LogRotator', numToKeepStr: '10']]])
 
-node('docker') {
+node('docker&&linux') {
     checkout scm
 
     /* Using this hack right now to grab the appropriate abbreviated SHA1 of


### PR DESCRIPTION
When Windows docker agents are available make sure this lands on a Linux docker agent.